### PR TITLE
Fix compatibility with ROS2 Jazzy+

### DIFF
--- a/gmapper/include/gmapper/mapper.h
+++ b/gmapper/include/gmapper/mapper.h
@@ -14,7 +14,7 @@
 #include "geometry_msgs/msg/pose.hpp"
 #include "geometry_msgs/msg/pose_stamped.hpp"
 #include "geometry_msgs/msg/transform_stamped.hpp"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.h"
+#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 #include "tf2_ros/transform_listener.h"
 #include "tf2_ros/transform_broadcaster.h"
 #include "tf2/utils.h"

--- a/gmapper/launch/gmap.launch.py
+++ b/gmapper/launch/gmap.launch.py
@@ -8,5 +8,5 @@ def generate_launch_description():
     use_sim_time = launch.substitutions.LaunchConfiguration('use_sim_time', default='true')
     return LaunchDescription([
         launch_ros.actions.Node(
-            package='gmapper', node_executable='gmap', output='screen', parameters=[{'use_sim_time':use_sim_time}]),
+            package='gmapper', executable='gmap', output='screen', parameters=[{'use_sim_time':use_sim_time}]),
     ])

--- a/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h
+++ b/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h
@@ -137,9 +137,10 @@ void rle(OutputIterator& out, const Iterator & begin, const Iterator & end){
 			count=1;
 		}
 	}
-	if (count>0)
+	if (count>0) {
 		*out=std::make_pair(current,count);
 		out++;
+	}
 }
 
 //BEGIN legacy


### PR DESCRIPTION
Fixes for `gmapper`  compatibility errors with newer versions of ROS2


```cmake
Starting >>> gmapper
--- stderr: gmapper
In file included from <WORKSPACE>/src/gmapper/src/mapper.cpp:1:
<WORKSPACE>/src/gmapper/include/gmapper/mapper.h:17:10: fatal error: tf2_geometry_msgs/tf2_geometry_msgs.h: No such file or directory
   17 | #include "tf2_geometry_msgs/tf2_geometry_msgs.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
gmake[2]: *** [CMakeFiles/gmap.dir/build.make:76: CMakeFiles/gmap.dir/src/mapper.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/gmap.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< gmapper [0.84s, exited with code 2]
```

```cmake
Starting >>> gmapper
--- stderr: gmapper
In file included from <WORKSPACE>/install/openslam_gmapping/include/gmapping/gridfastslam/gridslamprocessor.h:9,
                 from <WORKSPACE>/src/gmapper/include/gmapper/mapper.h:24,
                 from <WORKSPACE>/src/gmapper/src/mapper.cpp:1:
<WORKSPACE>/install/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h: In function ‘void rle(OutputIterator&, const Iterator&, const Iterator&)’:
<WORKSPACE>/install/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h:140:9: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
  140 |         if (count>0)
      |         ^~
<WORKSPACE>/install/openslam_gmapping/include/gmapping/particlefilter/particlefilter.h:142:17: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  142 |                 out++;
      |                 ^~~
---
```
